### PR TITLE
Exclude rails majors from dependabot group updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,11 @@ updates:
     schedule:
       interval: "weekly"
       day: "friday"
+    ignore:
+      # Rails major version upgrades are intentional, multi-step projects.
+      # Handle them via a dedicated upgrade PR, not a grouped bundler bump.
+      - dependency-name: "rails"
+        update-types: ["version-update:semver-major"]
     groups:
       minor-and-patch:
         update-types:


### PR DESCRIPTION
## Summary
- PR #14 swept Rails 7.1 -> 8.1 into the minor-and-patch bundler group, which is a multi-version major upgrade that warrants its own dedicated effort rather than a grouped dependency bump.
- Adds an ignore rule so dependabot never groups rails major version updates again. Minor and patch updates for rails still flow through as normal.
- Sidekiq, devise, and other gems are intentionally left alone -- they already get their own individual dependabot PRs for majors.

## Test plan
- [ ] Merge this PR
- [ ] Close PR #14 so dependabot regenerates a fresh group PR without rails
- [ ] Confirm the next dependabot run produces a smaller group PR that excludes rails