### PR TITLE
Exclude rails from dependabot minor-and-patch group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,8 @@ updates:
         update-types: ["version-update:semver-major"]
     groups:
       minor-and-patch:
+        exclude-patterns:
+          - "rails"
         update-types:
           - "minor"
           - "patch"


### PR DESCRIPTION
## Summary
- #15 added a top-level ignore for rails semver-major updates, but PR #16 was regenerated and still bumped Rails 7.1 -> 8.1 as part of the grouped update. Top-level ignore does not appear to apply to grouped updates in practice.
- Adds a group-level \`exclude-patterns: ["rails"]\` as a belt-and-suspenders guarantee that rails never rides along with a bundler group bump.
- Rails updates will still come through as their own dependabot PRs, filtered by the existing top-level ignore so majors never get proposed -- only minor/patch rails updates will ever appear, and only as standalone PRs.

## Test plan
- [ ] Merge this PR
- [ ] Close PR #16 so dependabot regenerates a fresh group PR without rails
- [ ] Confirm the regenerated group PR does not touch the \`rails\` gem