### PR TITLE
Remove bundler grouping from dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,16 +7,9 @@ updates:
       day: "friday"
     ignore:
       # Rails major version upgrades are intentional, multi-step projects.
-      # Handle them via a dedicated upgrade PR, not a grouped bundler bump.
+      # Handle them via a dedicated upgrade PR, not a routine dependabot bump.
       - dependency-name: "rails"
         update-types: ["version-update:semver-major"]
-    groups:
-      minor-and-patch:
-        exclude-patterns:
-          - "rails"
-        update-types:
-          - "minor"
-          - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Summary
- PRs #14, #16, and #21 all tried to sweep Rails 7.1 -> 8.1 into the minor-and-patch group even after we added a top-level ignore rule (#15) and a group-level exclude-patterns (#20).
- Root cause: web-console 4.3.0 requires railties >= 8.0.0. Dependabot cascade-bumps rails to satisfy the group resolution -- silently, without listing rails in the PR body, and bypassing both the ignore and exclude-patterns filters. Cascading bumps are not constrained by either filter.
- Abandoning grouping entirely for bundler. Each gem will get its own PR. Trade-off: more PRs, but each one is small, scope is explicit, and a rails-8 requirement from a single gem can be rejected with one click instead of cascading silently.
- The top-level rails semver-major ignore stays so rails never gets proposed as an individual PR either, until we do the upgrade as a dedicated project.
- github-actions grouping is left intact -- no cascade risk there.

## Test plan
- [ ] Merge this PR
- [ ] Close PR #21 (the broken group PR)
- [ ] Trigger a fresh dependabot run on the Gemfile row
- [ ] Confirm dependabot opens individual PRs for each non-rails gem
- [ ] Confirm no PR bumps rails