### PR TITLE
Fix flaky user role authorization system specs

### DIFF
--- a/spec/system/user_role_authorization_spec.rb
+++ b/spec/system/user_role_authorization_spec.rb
@@ -39,8 +39,8 @@ RSpec.describe 'User Role Authorization', :js do
     it 'can access admin management section' do
       visit root_path
 
-      # Admin should see Administration section in sidebar
-      expect(page.html).to include('Administration')
+      # Sidebar CSS uppercases the heading, so match case-insensitively.
+      expect(page).to have_content(/administration/i)
       expect(page).to have_link('Users')
 
       # Admin should be able to access admin management
@@ -111,8 +111,8 @@ RSpec.describe 'User Role Authorization', :js do
     it 'cannot access admin management section' do
       visit root_path
 
-      # Regular user should NOT see ADMINISTRATION section in sidebar
-      expect(page).to have_no_content('Administration')
+      # Regular user should NOT see Administration section in sidebar
+      expect(page).to have_no_content(/administration/i)
       expect(page).to have_no_link('Users')
     end
 
@@ -166,6 +166,7 @@ RSpec.describe 'User Role Authorization', :js do
       fill_in 'Email', with: 'regular@example.com'
       # Leave Admin checkbox unchecked
 
+      expect(page).to have_field('Email', with: 'regular@example.com')
       click_button 'Send Invitation'
 
       # Should create regular user
@@ -176,10 +177,16 @@ RSpec.describe 'User Role Authorization', :js do
     it 'allows admin to invite admin users' do
       visit new_user_path
 
+      expect(page).to have_field('Email')
+      expect(page).to have_field('user_admin_role_admin', type: 'checkbox')
+
       # Fill out form for admin user
       fill_in 'Email', with: 'newadmin@example.com'
       check 'Admin' # Check the admin checkbox
 
+      # Wait for the check to settle before submitting so Selenium's element
+      # handle to the submit button isn't invalidated by concurrent DOM work.
+      expect(page).to have_checked_field('user_admin_role_admin')
       click_button 'Send Invitation'
 
       # Should create admin user


### PR DESCRIPTION
## Summary

Two specs in `spec/system/user_role_authorization_spec.rb` had latent flakes that surfaced today on two Dependabot PRs (#29 importmap-rails, #32 rubocop-rspec_rails) despite being unrelated to the bumped gems. Main had been intermittently green by luck.

### Admin management section (`line 43`)

```ruby
expect(page.html).to include('Administration')
```

`page.html` reads the DOM snapshot immediately and bypasses Capybara's waiting matchers. When the sidebar partial had not yet rendered after `visit root_path`, the assertion failed with a head-only HTML diff. Two issues compounded:

1. **No wait** -- `page.html` + raw string `include` has no retry loop.
2. **CSS text-transform** -- the sidebar heading is rendered via `text-transform: uppercase`, so the visible text is `ADMINISTRATION`. A naive swap to `have_content('Administration')` would fail because `have_content` compares against visible text after CSS is applied.

Fix: `expect(page).to have_content(/administration/i)` -- case-insensitive regex uses Capybara's wait loop and handles the CSS.

Mirrored the change on the regular-user negative assertion (`line 115`) for symmetry.

### Invite admin users (`line 177`)

```ruby
check 'Admin'
click_button 'Send Invitation'
```

Intermittently failed with:

```
Selenium::WebDriver::Error::UnknownError:
  Node with given id does not belong to the document
```

The submit button's element handle could be invalidated between resolution and click while concurrent DOM work (Bootstrap JS, Turbo idle work) was still in flight. Adding `expect(page).to have_checked_field('user_admin_role_admin')` between the check and the click forces Capybara to wait for the prior interaction to settle before the submit button is re-resolved.

Mirrored with a `have_field('Email', with: 'regular@example.com')` guard in the regular-user invite spec (`line 169`) which shares the same submit pattern.

## Verification

- 8 consecutive local runs of the full spec file pass (previously failed ~1/5)
- `bundle exec rake` clean: 538 examples / 0 failures, 145 files / 0 rubocop offenses

## Test plan

- [ ] CI green on this branch
- [ ] Rebase the five open dependabot PRs on main after merge and confirm the two failing ones now pass