### PR TITLE
Accurate, Hoverable Chart Glossary

### DIFF
--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -57,6 +57,10 @@ module DashboardHelper
     keys.map { |key| METRIC_DEFINITIONS.fetch(key) }
   end
 
+  # Returned value is interpolated into JS string literals in dashboard/index.html.erb
+  # via `label: "<%= metric_label(:foo) %>"`. Keep titles ASCII without quotes,
+  # backslashes, or control characters so ERB's default HTML escape produces a
+  # well-formed JS string for any future title.
   def metric_label(key)
     METRIC_DEFINITIONS.fetch(key)[:title]
   end

--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -13,14 +13,16 @@ module DashboardHelper
       body: 'Pull requests closed during the week without being merged.'
     },
     late_prs: {
-      title: 'Late PRs',
-      body: 'Open, non-draft, approved PRs whose first approval was more than 7 ' \
-            'and fewer than 28 days before the end of the week (8-27 days approved-but-unmerged).'
+      title: 'Late Approved PRs',
+      body: 'Counted only for PRs that are open, non-draft, and have at least one approval. ' \
+            'Within that population, this is the count whose first approval landed more than 7 ' \
+            'and fewer than 28 days before the end of the week (i.e., 8-27 days approved-but-unmerged).'
     },
     stale_prs: {
-      title: 'Stale PRs',
-      body: 'Open, non-draft, approved PRs whose first approval was 28 or more days ' \
-            'before the end of the week. PRs move from Late into Stale at the 28-day mark.'
+      title: 'Stale Approved PRs',
+      body: 'Counted only for PRs that are open, non-draft, and have at least one approval. ' \
+            'Within that population, this is the count whose first approval landed 28 or more days ' \
+            'before the end of the week. PRs move from Late Approved into Stale Approved at the 28-day mark.'
     },
     hours_to_first_review: {
       title: 'Hours to First Review',

--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -38,11 +38,19 @@ module DashboardHelper
     },
     merge_rate: {
       title: 'Merge Rate (%)',
-      body: 'Percentage of PRs closed during the window that were merged (vs. cancelled).'
+      body: '(PRs merged in the last four weeks) divided by (PRs started in the last four weeks), as a percentage. ' \
+            'Note: not a strict cohort ratio -- the merged set and the started set may not be the same PRs, ' \
+            'since a PR can start outside the window and merge inside, or vice versa.'
     },
-    four_week_window: {
-      title: '4-Week Window',
-      body: 'Comparison values are averaged or summed across the most recent four full weeks of data.'
+    total_prs_4_weeks: {
+      title: 'Total PRs (4 weeks)',
+      body: 'Sum of "PRs Started" across the most recent four full weeks of data for the repository.'
+    },
+    avg_review_time_hours: {
+      title: 'Avg Review Time (hours)',
+      body: 'Average of each week\'s "Hours to First Review" across the most recent four full weeks of data ' \
+            'for the repository. Same underlying calculation as the Review Performance chart -- weekday hours only ' \
+            '(Saturdays and Sundays skipped, weekdays count all 24 hours, no business-hours cap).'
     }
   }.freeze
 

--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -24,13 +24,15 @@ module DashboardHelper
     },
     hours_to_first_review: {
       title: 'Hours to First Review',
-      body: 'Average weekday hours between a PR becoming ready for review and its first review. ' \
-            'Weekends are excluded so off-hours do not skew the metric.'
+      body: 'Average hours between a PR becoming ready for review and its first review. ' \
+            'Time on Saturdays and Sundays is skipped entirely, but weekdays count all 24 hours -- ' \
+            'there is no business-hours cap, so a PR sitting overnight Tuesday into Wednesday accrues those hours.'
     },
     hours_to_merge: {
       title: 'Hours to Merge',
-      body: 'Average weekday hours between a PR becoming ready for review and being merged. ' \
-            'Weekends are excluded so off-hours do not skew the metric.'
+      body: 'Average hours between a PR becoming ready for review and being merged. ' \
+            'Time on Saturdays and Sundays is skipped entirely, but weekdays count all 24 hours -- ' \
+            'there is no business-hours cap, so a PR sitting overnight Tuesday into Wednesday accrues those hours.'
     },
     merge_rate: {
       title: 'Merge Rate (%)',

--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -1,4 +1,7 @@
 module DashboardHelper
+  WEEKDAY_HOURS_RULE = 'Time on Saturdays and Sundays is skipped entirely, but weekdays count all 24 hours -- ' \
+                       'there is no business-hours cap, so a PR sitting overnight Tuesday into Wednesday accrues those hours.'.freeze
+
   METRIC_DEFINITIONS = {
     prs_started: {
       title: 'PRs Started',
@@ -26,15 +29,11 @@ module DashboardHelper
     },
     hours_to_first_review: {
       title: 'Hours to First Review',
-      body: 'Average hours between a PR becoming ready for review and its first review. ' \
-            'Time on Saturdays and Sundays is skipped entirely, but weekdays count all 24 hours -- ' \
-            'there is no business-hours cap, so a PR sitting overnight Tuesday into Wednesday accrues those hours.'
+      body: "Average hours between a PR becoming ready for review and its first review. #{WEEKDAY_HOURS_RULE}"
     },
     hours_to_merge: {
       title: 'Hours to Merge',
-      body: 'Average hours between a PR becoming ready for review and being merged. ' \
-            'Time on Saturdays and Sundays is skipped entirely, but weekdays count all 24 hours -- ' \
-            'there is no business-hours cap, so a PR sitting overnight Tuesday into Wednesday accrues those hours.'
+      body: "Average hours between a PR becoming ready for review and being merged. #{WEEKDAY_HOURS_RULE}"
     },
     merge_rate: {
       title: 'Merge Rate (%)',
@@ -56,5 +55,9 @@ module DashboardHelper
 
   def metric_definitions(*keys)
     keys.map { |key| METRIC_DEFINITIONS.fetch(key) }
+  end
+
+  def metric_label(key)
+    METRIC_DEFINITIONS.fetch(key)[:title]
   end
 end

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -159,7 +159,7 @@
                     Repository Performance Comparison
                     <%= render 'shared/metric_info',
                                chart_label: 'Repository Performance Comparison',
-                               keys: %i[four_week_window merge_rate hours_to_first_review] %>
+                               keys: %i[total_prs_4_weeks avg_review_time_hours merge_rate] %>
                 </h6>
                 <small class="text-muted">Last 4 weeks average</small>
             </div>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -342,7 +342,7 @@ document.addEventListener('DOMContentLoaded', function() {
         data: {
             labels: [<%= @chart_weeks.map { |w| "'#{w.begin_date.strftime('%b %d')}'" }.join(', ').html_safe %>],
             datasets: [{
-                label: '<%= metric_label(:prs_started) %>',
+                label: "<%= metric_label(:prs_started) %>",
                 data: [<%= @chart_weeks.map(&:num_prs_started).join(', ') %>],
                 borderColor: '#4e73df',
                 backgroundColor: 'rgba(78, 115, 223, 0.1)',
@@ -350,7 +350,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 fill: true,
                 tension: 0.3
             }, {
-                label: '<%= metric_label(:prs_merged) %>',
+                label: "<%= metric_label(:prs_merged) %>",
                 data: [<%= @chart_weeks.map(&:num_prs_merged).join(', ') %>],
                 borderColor: '#1cc88a',
                 backgroundColor: 'rgba(28, 200, 138, 0.1)',
@@ -359,7 +359,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 tension: 0.3
             }, {
                 // Unfilled line to visually de-emphasize the negative metric
-                label: '<%= metric_label(:prs_cancelled) %>',
+                label: "<%= metric_label(:prs_cancelled) %>",
                 data: [<%= @chart_weeks.map(&:num_prs_cancelled).join(', ') %>],
                 borderColor: '#e74a3b',
                 backgroundColor: 'rgba(231, 74, 59, 0.1)',
@@ -368,7 +368,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 tension: 0.3
             }, {
                 // Orange to indicate warning (8-27 days approved-but-unmerged)
-                label: '<%= metric_label(:late_prs) %>',
+                label: "<%= metric_label(:late_prs) %>",
                 data: [<%= @chart_weeks.map(&:num_prs_late).join(', ') %>],
                 borderColor: '#f6c23e',
                 backgroundColor: 'rgba(246, 194, 62, 0.1)',
@@ -377,7 +377,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 tension: 0.3
             }, {
                 // Red to indicate urgency (28+ days approved-but-unmerged)
-                label: '<%= metric_label(:stale_prs) %>',
+                label: "<%= metric_label(:stale_prs) %>",
                 data: [<%= @chart_weeks.map(&:num_prs_stale).join(', ') %>],
                 borderColor: '#e74a3b',
                 backgroundColor: 'rgba(231, 74, 59, 0.2)',
@@ -426,7 +426,7 @@ document.addEventListener('DOMContentLoaded', function() {
         data: {
             labels: [<%= @chart_weeks.map { |w| "'#{w.begin_date.strftime('%b %d')}'" }.join(', ').html_safe %>],
             datasets: [{
-                label: '<%= metric_label(:hours_to_first_review) %>',
+                label: "<%= metric_label(:hours_to_first_review) %>",
                 data: [<%= @chart_weeks.map { |w| w.avg_hrs_to_first_review || 0 }.join(', ') %>],
                 borderColor: '#f6c23e',
                 backgroundColor: 'rgba(246, 194, 62, 0.1)',
@@ -434,7 +434,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 fill: true,
                 tension: 0.3
             }, {
-                label: '<%= metric_label(:hours_to_merge) %>',
+                label: "<%= metric_label(:hours_to_merge) %>",
                 data: [<%= @chart_weeks.map { |w| w.avg_hrs_to_merge || 0 }.join(', ') %>],
                 borderColor: '#1cc88a',
                 backgroundColor: 'rgba(28, 200, 138, 0.1)',
@@ -489,20 +489,20 @@ document.addEventListener('DOMContentLoaded', function() {
         data: {
             labels: [<%= @repository_stats.map { |r| "'#{r[:name]}'" }.join(', ').html_safe %>],
             datasets: [{
-                label: '<%= metric_label(:total_prs_4_weeks) %>',
+                label: "<%= metric_label(:total_prs_4_weeks) %>",
                 data: [<%= @repository_stats.map { |r| r[:total_prs] }.join(', ') %>],
                 backgroundColor: '#4e73df',
                 borderColor: '#4e73df',
                 borderWidth: 1
             }, {
-                label: '<%= metric_label(:avg_review_time_hours) %>',
+                label: "<%= metric_label(:avg_review_time_hours) %>",
                 data: [<%= @repository_stats.map { |r| r[:avg_review_time].round(1) }.join(', ') %>],
                 backgroundColor: '#f6c23e',
                 borderColor: '#f6c23e',
                 borderWidth: 1,
                 yAxisID: 'y1'
             }, {
-                label: '<%= metric_label(:merge_rate) %>',
+                label: "<%= metric_label(:merge_rate) %>",
                 data: [<%= @repository_stats.map { |r| r[:merge_rate] }.join(', ') %>],
                 backgroundColor: '#1cc88a',
                 borderColor: '#1cc88a',

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -367,8 +367,8 @@ document.addEventListener('DOMContentLoaded', function() {
                 fill: false,
                 tension: 0.3
             }, {
-                // Late PRs (approved 8-27 days ago) styled in orange to indicate warning
-                label: 'Late PRs',
+                // Late Approved PRs (approved 8-27 days ago) styled in orange to indicate warning
+                label: 'Late Approved PRs',
                 data: [<%= @chart_weeks.map(&:num_prs_late).join(', ') %>],
                 borderColor: '#f6c23e',
                 backgroundColor: 'rgba(246, 194, 62, 0.1)',
@@ -376,8 +376,8 @@ document.addEventListener('DOMContentLoaded', function() {
                 fill: true,
                 tension: 0.3
             }, {
-                // Stale PRs (approved 28+ days ago) styled in red to indicate urgency
-                label: 'Stale PRs',
+                // Stale Approved PRs (approved 28+ days ago) styled in red to indicate urgency
+                label: 'Stale Approved PRs',
                 data: [<%= @chart_weeks.map(&:num_prs_stale).join(', ') %>],
                 borderColor: '#e74a3b',
                 backgroundColor: 'rgba(231, 74, 59, 0.2)',

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -342,7 +342,7 @@ document.addEventListener('DOMContentLoaded', function() {
         data: {
             labels: [<%= @chart_weeks.map { |w| "'#{w.begin_date.strftime('%b %d')}'" }.join(', ').html_safe %>],
             datasets: [{
-                label: 'PRs Started',
+                label: '<%= metric_label(:prs_started) %>',
                 data: [<%= @chart_weeks.map(&:num_prs_started).join(', ') %>],
                 borderColor: '#4e73df',
                 backgroundColor: 'rgba(78, 115, 223, 0.1)',
@@ -350,7 +350,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 fill: true,
                 tension: 0.3
             }, {
-                label: 'PRs Merged',
+                label: '<%= metric_label(:prs_merged) %>',
                 data: [<%= @chart_weeks.map(&:num_prs_merged).join(', ') %>],
                 borderColor: '#1cc88a',
                 backgroundColor: 'rgba(28, 200, 138, 0.1)',
@@ -358,8 +358,8 @@ document.addEventListener('DOMContentLoaded', function() {
                 fill: true,
                 tension: 0.3
             }, {
-                // Cancelled PRs styled as unfilled line to visually de-emphasize negative metric
-                label: 'PRs Cancelled',
+                // Unfilled line to visually de-emphasize the negative metric
+                label: '<%= metric_label(:prs_cancelled) %>',
                 data: [<%= @chart_weeks.map(&:num_prs_cancelled).join(', ') %>],
                 borderColor: '#e74a3b',
                 backgroundColor: 'rgba(231, 74, 59, 0.1)',
@@ -367,8 +367,8 @@ document.addEventListener('DOMContentLoaded', function() {
                 fill: false,
                 tension: 0.3
             }, {
-                // Late Approved PRs (approved 8-27 days ago) styled in orange to indicate warning
-                label: 'Late Approved PRs',
+                // Orange to indicate warning (8-27 days approved-but-unmerged)
+                label: '<%= metric_label(:late_prs) %>',
                 data: [<%= @chart_weeks.map(&:num_prs_late).join(', ') %>],
                 borderColor: '#f6c23e',
                 backgroundColor: 'rgba(246, 194, 62, 0.1)',
@@ -376,8 +376,8 @@ document.addEventListener('DOMContentLoaded', function() {
                 fill: true,
                 tension: 0.3
             }, {
-                // Stale Approved PRs (approved 28+ days ago) styled in red to indicate urgency
-                label: 'Stale Approved PRs',
+                // Red to indicate urgency (28+ days approved-but-unmerged)
+                label: '<%= metric_label(:stale_prs) %>',
                 data: [<%= @chart_weeks.map(&:num_prs_stale).join(', ') %>],
                 borderColor: '#e74a3b',
                 backgroundColor: 'rgba(231, 74, 59, 0.2)',
@@ -426,7 +426,7 @@ document.addEventListener('DOMContentLoaded', function() {
         data: {
             labels: [<%= @chart_weeks.map { |w| "'#{w.begin_date.strftime('%b %d')}'" }.join(', ').html_safe %>],
             datasets: [{
-                label: 'Hours to First Review',
+                label: '<%= metric_label(:hours_to_first_review) %>',
                 data: [<%= @chart_weeks.map { |w| w.avg_hrs_to_first_review || 0 }.join(', ') %>],
                 borderColor: '#f6c23e',
                 backgroundColor: 'rgba(246, 194, 62, 0.1)',
@@ -434,7 +434,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 fill: true,
                 tension: 0.3
             }, {
-                label: 'Hours to Merge',
+                label: '<%= metric_label(:hours_to_merge) %>',
                 data: [<%= @chart_weeks.map { |w| w.avg_hrs_to_merge || 0 }.join(', ') %>],
                 borderColor: '#1cc88a',
                 backgroundColor: 'rgba(28, 200, 138, 0.1)',
@@ -489,20 +489,20 @@ document.addEventListener('DOMContentLoaded', function() {
         data: {
             labels: [<%= @repository_stats.map { |r| "'#{r[:name]}'" }.join(', ').html_safe %>],
             datasets: [{
-                label: 'Total PRs (4 weeks)',
+                label: '<%= metric_label(:total_prs_4_weeks) %>',
                 data: [<%= @repository_stats.map { |r| r[:total_prs] }.join(', ') %>],
                 backgroundColor: '#4e73df',
                 borderColor: '#4e73df',
                 borderWidth: 1
             }, {
-                label: 'Avg Review Time (hours)',
+                label: '<%= metric_label(:avg_review_time_hours) %>',
                 data: [<%= @repository_stats.map { |r| r[:avg_review_time].round(1) }.join(', ') %>],
                 backgroundColor: '#f6c23e',
                 borderColor: '#f6c23e',
                 borderWidth: 1,
                 yAxisID: 'y1'
             }, {
-                label: 'Merge Rate (%)',
+                label: '<%= metric_label(:merge_rate) %>',
                 data: [<%= @repository_stats.map { |r| r[:merge_rate] }.join(', ') %>],
                 backgroundColor: '#1cc88a',
                 borderColor: '#1cc88a',

--- a/app/views/shared/_metric_info.html.erb
+++ b/app/views/shared/_metric_info.html.erb
@@ -12,7 +12,7 @@
       data: {
         toggle: 'popover',
         html: 'true',
-        trigger: 'focus',
+        trigger: 'hover focus',
         placement: 'bottom',
         title: chart_label,
         content: popover_body

--- a/app/views/weeks/show.html.erb
+++ b/app/views/weeks/show.html.erb
@@ -14,8 +14,8 @@
   <li>PRs Started: <%= @week.started_prs.count %> (<a href="#" class="view-prs" data-category="started">View PRs</a>)</li>
   <li>PRs First Reviewed: <%= @week.first_review_prs.count %> (<a href="#" class="view-prs" data-category="first_reviewed">View PRs</a>)</li>
   <li>Avg Hours to First Review: <%= @week.avg_hours_to_first_review&.round(2) || 'N/A' %> hrs</li>
-  <li>Late PRs: <%= @week.num_prs_late %> (<a href="#" class="view-prs" data-category="late">View PRs</a>)</li>
-  <li>Stale PRs: <%= @week.num_prs_stale %> (<a href="#" class="view-prs" data-category="stale">View PRs</a>)</li>
+  <li>Late Approved PRs: <%= @week.num_prs_late %> (<a href="#" class="view-prs" data-category="late">View PRs</a>)</li>
+  <li>Stale Approved PRs: <%= @week.num_prs_stale %> (<a href="#" class="view-prs" data-category="stale">View PRs</a>)</li>
   <li>PRs Merged: <%= @week.merged_prs.count %> (<a href="#" class="view-prs" data-category="merged">View PRs</a>)</li>
   <li>Avg Hours to Merge: <%= @week.avg_hours_to_merge&.round(2) || 'N/A' %> hrs</li>
   <li>PRs Cancelled: <%= @week.cancelled_prs.count %> (<a href="#" class="view-prs" data-category="cancelled">View PRs</a>)</li>

--- a/spec/helpers/dashboard_helper_spec.rb
+++ b/spec/helpers/dashboard_helper_spec.rb
@@ -48,10 +48,6 @@ RSpec.describe DashboardHelper do
       expect(body).not_to include('closed')
     end
 
-    it 'no longer exposes the four_week_window meta-entry' do
-      expect { helper.metric_definitions(:four_week_window) }.to raise_error(KeyError)
-    end
-
     it 'states explicitly which days are excluded and that weekdays have no hourly cap' do
       review_def = helper.metric_definitions(:hours_to_first_review).first
       merge_def = helper.metric_definitions(:hours_to_merge).first

--- a/spec/helpers/dashboard_helper_spec.rb
+++ b/spec/helpers/dashboard_helper_spec.rb
@@ -30,10 +30,26 @@ RSpec.describe DashboardHelper do
       expect(body).to include('28 or more days')
     end
 
-    it 'defines the cancelled, hours, merge rate, and four-week-window metrics' do
-      keys = %i[prs_cancelled hours_to_first_review hours_to_merge merge_rate four_week_window]
+    it 'defines a key whose title matches each Repository Performance Comparison chart label' do
+      total_prs = helper.metric_definitions(:total_prs_4_weeks).first
+      avg_review = helper.metric_definitions(:avg_review_time_hours).first
+      merge_rate = helper.metric_definitions(:merge_rate).first
 
-      expect { helper.metric_definitions(*keys) }.not_to raise_error
+      expect(total_prs[:title]).to eq('Total PRs (4 weeks)')
+      expect(avg_review[:title]).to eq('Avg Review Time (hours)')
+      expect(merge_rate[:title]).to eq('Merge Rate (%)')
+    end
+
+    it 'describes merge_rate as merged-divided-by-started, not merged-divided-by-closed' do
+      body = helper.metric_definitions(:merge_rate).first[:body]
+
+      expect(body).to include('merged')
+      expect(body).to include('started')
+      expect(body).not_to include('closed')
+    end
+
+    it 'no longer exposes the four_week_window meta-entry' do
+      expect { helper.metric_definitions(:four_week_window) }.to raise_error(KeyError)
     end
 
     it 'states explicitly which days are excluded and that weekdays have no hourly cap' do

--- a/spec/helpers/dashboard_helper_spec.rb
+++ b/spec/helpers/dashboard_helper_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe DashboardHelper do
       expect(body).not_to include('closed')
     end
 
-    it 'states explicitly which days are excluded and that weekdays have no hourly cap' do
+    it 'states explicitly which days are excluded and that weekdays have no hourly cap', :aggregate_failures do
       review_def = helper.metric_definitions(:hours_to_first_review).first
       merge_def = helper.metric_definitions(:hours_to_merge).first
 

--- a/spec/helpers/dashboard_helper_spec.rb
+++ b/spec/helpers/dashboard_helper_spec.rb
@@ -35,6 +35,16 @@ RSpec.describe DashboardHelper do
       expect { helper.metric_definitions(*keys) }.not_to raise_error
     end
 
+    it 'states explicitly which days are excluded and that weekdays have no hourly cap' do
+      review_def = helper.metric_definitions(:hours_to_first_review).first
+      merge_def = helper.metric_definitions(:hours_to_merge).first
+
+      [review_def, merge_def].each do |defn|
+        expect(defn[:body]).to include('Saturdays and Sundays')
+        expect(defn[:body]).to include('no business-hours cap')
+      end
+    end
+
     it 'raises KeyError for unknown metric keys' do
       expect { helper.metric_definitions(:not_a_metric) }.to raise_error(KeyError)
     end

--- a/spec/helpers/dashboard_helper_spec.rb
+++ b/spec/helpers/dashboard_helper_spec.rb
@@ -13,20 +13,21 @@ RSpec.describe DashboardHelper do
     it 'preserves the order of requested keys' do
       result = helper.metric_definitions(:stale_prs, :late_prs)
 
-      expect(result.pluck(:title)).to eq(['Stale PRs', 'Late PRs'])
+      expect(result.pluck(:title)).to eq(['Stale Approved PRs', 'Late Approved PRs'])
     end
 
-    it 'states the 7-day threshold for late PRs' do
-      definition = helper.metric_definitions(:late_prs).first
+    it 'leads the late PRs definition with the open/non-draft/approved filter' do
+      body = helper.metric_definitions(:late_prs).first[:body]
 
-      expect(definition[:body]).to include('7')
-      expect(definition[:body]).to include('28')
+      expect(body).to start_with('Counted only for PRs that are open, non-draft, and have at least one approval')
+      expect(body).to include('more than 7 and fewer than 28 days')
     end
 
-    it 'states the 28-day threshold for stale PRs' do
-      definition = helper.metric_definitions(:stale_prs).first
+    it 'leads the stale PRs definition with the open/non-draft/approved filter' do
+      body = helper.metric_definitions(:stale_prs).first[:body]
 
-      expect(definition[:body]).to include('28')
+      expect(body).to start_with('Counted only for PRs that are open, non-draft, and have at least one approval')
+      expect(body).to include('28 or more days')
     end
 
     it 'defines the cancelled, hours, merge rate, and four-week-window metrics' do

--- a/spec/requests/dashboard_metric_definitions_spec.rb
+++ b/spec/requests/dashboard_metric_definitions_spec.rb
@@ -20,14 +20,14 @@ RSpec.describe 'Dashboard metric definitions' do
   it 'embeds the Late PRs definition with the 7-day threshold in popover content' do
     get dashboard_path
 
-    expect(response.body).to include('Late PRs')
+    expect(response.body).to include('Late Approved PRs')
     expect(response.body).to include('more than 7 and fewer than 28 days')
   end
 
   it 'embeds the Stale PRs definition with the 28-day threshold in popover content' do
     get dashboard_path
 
-    expect(response.body).to include('Stale PRs')
+    expect(response.body).to include('Stale Approved PRs')
     expect(response.body).to include('28 or more days')
   end
 

--- a/spec/requests/week_metric_definitions_spec.rb
+++ b/spec/requests/week_metric_definitions_spec.rb
@@ -20,9 +20,9 @@ RSpec.describe 'Week show metric definitions' do
   it 'embeds the Late and Stale threshold definitions in popover content' do
     get repository_week_path(repository, week)
 
-    expect(response.body).to include('Late PRs')
+    expect(response.body).to include('Late Approved PRs')
     expect(response.body).to include('more than 7 and fewer than 28 days')
-    expect(response.body).to include('Stale PRs')
+    expect(response.body).to include('Stale Approved PRs')
     expect(response.body).to include('28 or more days')
   end
 end

--- a/spec/system/dashboard_late_stale_prs_chart_spec.rb
+++ b/spec/system/dashboard_late_stale_prs_chart_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe 'Dashboard Late and Stale PRs Chart', :js do
 
         expect(page).to have_content('PR Velocity Trends')
         expect(page).to have_css('canvas#prVelocityChart')
-        expect(page.html).to include('Late PRs')
+        expect(page.html).to include('Late Approved PRs')
       end
 
       it 'shows Stale PRs dataset in chart on main dashboard' do
@@ -48,7 +48,7 @@ RSpec.describe 'Dashboard Late and Stale PRs Chart', :js do
 
         expect(page).to have_content('PR Velocity Trends')
         expect(page).to have_css('canvas#prVelocityChart')
-        expect(page.html).to include('Stale PRs')
+        expect(page.html).to include('Stale Approved PRs')
       end
 
       it 'does not show old PRs Approved dataset' do
@@ -63,8 +63,8 @@ RSpec.describe 'Dashboard Late and Stale PRs Chart', :js do
 
         expect(page).to have_content('PR Velocity Trends')
         expect(page).to have_css('canvas#prVelocityChart')
-        expect(page.html).to include('Late PRs')
-        expect(page.html).to include('Stale PRs')
+        expect(page.html).to include('Late Approved PRs')
+        expect(page.html).to include('Stale Approved PRs')
         expect(page).to have_content("for #{repository.name}")
       end
     end
@@ -87,8 +87,8 @@ RSpec.describe 'Dashboard Late and Stale PRs Chart', :js do
 
         expect(page).to have_content('PR Velocity Trends')
         expect(page).to have_css('canvas#prVelocityChart')
-        expect(page.html).to include('Late PRs')
-        expect(page.html).to include('Stale PRs')
+        expect(page.html).to include('Late Approved PRs')
+        expect(page.html).to include('Stale Approved PRs')
       end
     end
   end

--- a/spec/system/dashboard_metric_popover_spec.rb
+++ b/spec/system/dashboard_metric_popover_spec.rb
@@ -33,12 +33,22 @@ RSpec.describe 'Dashboard metric popovers', :js do
     end
   end
 
-  it 'dismisses the popover when the trigger loses focus' do
+  it 'opens the popover when the trigger is hovered, no click required' do
+    expect(page).to have_css('#prVelocityChart')
+
+    find('button.metric-info-trigger[aria-label*="PR Velocity"]').hover
+
+    expect(page).to have_css('.popover.show', wait: 5)
+    within('.popover.show') { expect(page).to have_content('Late PRs') }
+  end
+
+  it 'dismisses the popover when the trigger loses both hover and focus' do
     expect(page).to have_css('#prVelocityChart')
 
     find('button.metric-info-trigger[aria-label*="Review Performance"]').click
     expect(page).to have_css('.popover.show', wait: 5)
 
+    find('h1', text: 'Dashboard').hover
     page.execute_script(
       'document.querySelector(\'button.metric-info-trigger[aria-label*="Review Performance"]\').blur()'
     )

--- a/spec/system/dashboard_metric_popover_spec.rb
+++ b/spec/system/dashboard_metric_popover_spec.rb
@@ -26,9 +26,9 @@ RSpec.describe 'Dashboard metric popovers', :js do
 
     expect(page).to have_css('.popover.show', wait: 5)
     within('.popover.show') do
-      expect(page).to have_content('Late PRs')
+      expect(page).to have_content('Late Approved PRs')
       expect(page).to have_content('more than 7')
-      expect(page).to have_content('Stale PRs')
+      expect(page).to have_content('Stale Approved PRs')
       expect(page).to have_content('28 or more days')
     end
   end
@@ -39,7 +39,7 @@ RSpec.describe 'Dashboard metric popovers', :js do
     find('button.metric-info-trigger[aria-label*="PR Velocity"]').hover
 
     expect(page).to have_css('.popover.show', wait: 5)
-    within('.popover.show') { expect(page).to have_content('Late PRs') }
+    within('.popover.show') { expect(page).to have_content('Late Approved PRs') }
   end
 
   it 'dismisses the popover when the trigger loses both hover and focus' do

--- a/spec/system/week_navigation_spec.rb
+++ b/spec/system/week_navigation_spec.rb
@@ -37,12 +37,12 @@ RSpec.describe 'Week Navigation', :js do
 
     it 'displays late PR count from cached column' do
       visit repository_week_path(repository, week)
-      expect(page).to have_content('Late PRs: 1')
+      expect(page).to have_content('Late Approved PRs: 1')
     end
 
     it 'displays stale PR count from cached column' do
       visit repository_week_path(repository, week)
-      expect(page).to have_content('Stale PRs: 1')
+      expect(page).to have_content('Stale Approved PRs: 1')
     end
 
     it 'allows viewing late PRs dynamically' do
@@ -73,7 +73,7 @@ RSpec.describe 'Week Navigation', :js do
              repository: repository, week: week, days_before_week_end: 7)
       WeekStatsService.new(week).update_stats
       visit repository_week_path(repository, week)
-      expect(page).to have_content('Late PRs: 0')
+      expect(page).to have_content('Late Approved PRs: 0')
     end
 
     it 'PR approved exactly 8 days before week end IS late' do
@@ -81,7 +81,7 @@ RSpec.describe 'Week Navigation', :js do
              repository: repository, week: week, days_before_week_end: 8)
       WeekStatsService.new(week).update_stats
       visit repository_week_path(repository, week)
-      expect(page).to have_content('Late PRs: 1')
+      expect(page).to have_content('Late Approved PRs: 1')
     end
 
     it 'PR approved exactly 28 days before week end IS stale (not late)' do
@@ -89,8 +89,8 @@ RSpec.describe 'Week Navigation', :js do
              repository: repository, week: week, days_before_week_end: 28)
       WeekStatsService.new(week).update_stats
       visit repository_week_path(repository, week)
-      expect(page).to have_content('Late PRs: 0')
-      expect(page).to have_content('Stale PRs: 1')
+      expect(page).to have_content('Late Approved PRs: 0')
+      expect(page).to have_content('Stale Approved PRs: 1')
     end
   end
 end


### PR DESCRIPTION
## Why

Follow-up polish for PR #39's metric-definition popovers, driven by user feedback after that landed in production. Four small fixes:

- Mouse users had to click each info icon. Hover should also work.
- The Hours to First Review / Hours to Merge bodies said "Weekends are excluded so off-hours do not skew the metric", which implied night/early-morning hours were also excluded. They aren't -- weekdays count all 24 hours, no business-hours cap.
- Late and Stale only count PRs that are open, non-draft, and approved. The chart legend "Late PRs" / "Stale PRs" hid that filter, and the popover bodies buried it mid-clause -- causing readers to forget the qualifier.
- The Repository Performance Comparison popover did not match the chart it described: the chart's three datasets are labeled "Total PRs (4 weeks)", "Avg Review Time (hours)", and "Merge Rate (%)", but the popover showed entries titled "Hours to First Review" and "4-Week Window". The Merge Rate definition was also wrong about what the code computes.

## What changes for readers

- **Hover the (i) icon** on any chart -- the popover opens. Mouse off, it dismisses. Click and keyboard tab still work as before.
- **"Late PRs" → "Late Approved PRs"** and **"Stale PRs" → "Stale Approved PRs"** in the chart legend, on the weeks/show statistics list, and in the popover titles. The popover bodies now lead with "Counted only for PRs that are open, non-draft, and have at least one approval" before describing the day-count threshold.
- **Hours to First Review / Hours to Merge** popovers honestly state that Saturdays and Sundays are skipped entirely but weekdays count all 24 hours, no business-hours cap.
- **Repository Performance Comparison** popover now has one entry per chart dataset, with titles that exactly match: "Total PRs (4 weeks)", "Avg Review Time (hours)", "Merge Rate (%)". The Merge Rate body describes the actual `merged ÷ started` ratio (not the previous misleading `merged ÷ closed`).

## Behavioral note for chart-prefs

Anyone with chart-visibility preferences saved in localStorage for the old "Late PRs" / "Stale PRs" labels will see the renamed datasets default-hide on first load (the saved label no longer matches a dataset). One legend-click per dataset re-shows them. Acceptable for an admin tool; a generic legacy-label migration was prototyped but skipped per maintainer call.

## Commits

1. `Hoverable Glossary` -- partial trigger flips from `'focus'` to `'hover focus'`; system spec adds an open-on-hover test and the dismiss test now releases both hover and focus.
2. `Honest Weekday-Hours Definitions` -- corrects the Hours bodies to match `WeekdayHours#weekday_hours_between` reality.
3. `"Approved" Up Front For Late/Stale` -- chart legend, weeks/show, and glossary all rename + glossary bodies lead with the qualifying conditions.
4. `Comparison Chart Glossary Matches Reality` -- adds `total_prs_4_weeks` and `avg_review_time_hours` entries with chart-matching titles, drops `four_week_window`, rewrites `merge_rate` body to reflect the controller's actual computation.

## Test plan

- [x] Helper, request, and system specs all pass; full `bundle exec rake` clean (557 examples, 0 failures; rubocop 0 offenses across 150 files)
- [x] Hover system spec verifies mouse-hover opens the popover with no click required
- [x] Updated dismiss spec verifies hover-off + blur dismisses the popover
- [ ] Manual on production after merge: hover each chart's info icon, confirm the popover opens; click the icon and confirm it pins; click elsewhere or tab away and confirm it dismisses
- [ ] Manual: confirm the chart legend now reads "Late Approved PRs" / "Stale Approved PRs" and the weeks/show list shows the same renamed labels
- [ ] Manual: confirm the Repository Performance Comparison popover lists "Total PRs (4 weeks)", "Avg Review Time (hours)", "Merge Rate (%)" -- in that order

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>